### PR TITLE
Put the contribute card back at the top of the grid

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -376,6 +376,9 @@ export default function Home({ agents, allCategories, allTags, allFrameworks, al
 
           {/* Agent Grid */}
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            {/* Leads the grid — at the end it sat below 19 cards and went unseen */}
+            <ContributeCard templateCount={agents.length} />
+
             {filteredAgents.length > 0 ? (
               filteredAgents.map((agent) => (
                 <AgentCard
@@ -394,9 +397,6 @@ export default function Home({ agents, allCategories, allTags, allFrameworks, al
                 </p>
               </div>
             )}
-
-            {/* Contribute card trails the library so real templates lead */}
-            <ContributeCard templateCount={agents.length} />
           </div>
         </div>
 


### PR DESCRIPTION
## Description

Reverts the card-ordering change from #3. Moving the contribute card after the templates buried it below 19 cards, so it went unseen — leading the grid is the point of the card, since it is a call to contribute rather than a footer.

## Type of Change
- [x] Bug fix

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors

## Verification

`npm run build` clean; checked in a real browser against the built output — the card leads the grid and sits flush with the row height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UNB1JYtaJqyns3dD6n8M49
